### PR TITLE
Fix python 3.12 compatibility

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   skip: true  # [(py==37 and aarch64)]
-  skip: true  # [py<37 or py>311]
+  skip: true  # [py<37 or py>312]
 
 requirements:
   build:
@@ -36,7 +36,7 @@ outputs:
         - pip
         - setuptools
       run:
-        - python >=3.7,<3.12
+        - python >=3.7,<3.13
 
     test:
       requires:
@@ -67,7 +67,7 @@ outputs:
         - pip
         - setuptools
       run:
-        - python >=3.7,<3.12
+        - python >=3.7,<3.13
         - {{ pin_subpackage("scikit-base", exact=True) }}
         - pandas
         - numpy


### PR DESCRIPTION
The package may have been missing 3.12 compatibility, at least tests:

https://github.com/sktime/skbase/issues/330

This PR attempts to fix the recipe.